### PR TITLE
Multiple role support

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -188,7 +188,15 @@ const checkIfHasAccess = (
   customMessage,
   response
 ) => {
-  if (isAllowed(method, permission)) return next()
+  let allowed
+  if (permission.length) {
+    allowed = permission.reduce((acc, p) => {
+      return acc || isAllowed(method, p)
+    }, false)
+  } else {
+    allowed = isAllowed(method, permission)
+  }
+  if (allowed) return next()
   return ctx.throw(403, deny(customMessage, response))
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,8 @@ let options = {
   path: '.',
   filename: 'nacl.json',
   policies: new Map(),
-  defaultRole: 'guest'
+  defaultRole: 'guest',
+  multipleRolePropertyName: 'id'
 }
 
 function config (config, response) {
@@ -25,8 +26,8 @@ function config (config, response) {
     let filePath = (options.filename && options.path)
       ? `${options.path}/${options.filename}`
       : options.filename
-
-    options.policies = mapPolicyToGroup(readConfigFile(filePath))
+    
+      options.policies = mapPolicyToGroup(readConfigFile(filePath))
   }
 
   if (!options.policies.size) {
@@ -51,9 +52,17 @@ function authorize (ctx, next) {
 
   if (ctx.request.originalUrl === '/') return next()
 
-  const policy = options.policies.get(role)
+  let policies
 
-  if (!policy) {
+  if (role.length) {
+    policies = role.map((r) => {
+      return options.policies.get(r[options.multipleRolePropertyName]);
+    })
+  } else {
+    policies = options.policies.get(role)
+  }
+
+  if (!policies) {
     ctx.status = 403
     ctx.body = {
       status: 'Access denied',
@@ -63,14 +72,27 @@ function authorize (ctx, next) {
     return
   }
 
-  const permission = findPermissionForRoute(
-    ctx.request.originalUrl,
-    ctx.request.method,
-    options.baseUrl,
-    policy
-  )
-
-  if (!permission) {
+  let permissions
+  
+  if (role.length) {
+    permissions = policies.map((policy) => {
+      return findPermissionForRoute(
+        ctx.request.originalUrl,
+        ctx.request.method,
+        options.baseUrl,
+        policy
+      )
+    })
+  } else {
+    permissions = findPermissionForRoute(
+      ctx.request.originalUrl,
+      ctx.request.method,
+      options.baseUrl,
+      policies
+    )
+  }
+  
+  if (!permissions) {
     return ctx.throw(401, deny(options.customMessage, options.response))
   }
 
@@ -78,7 +100,7 @@ function authorize (ctx, next) {
     ctx.method,
     ctx,
     next,
-    permission,
+    permissions,
     options.customMessage,
     options.response
   )


### PR DESCRIPTION
This PR enables support for users with multiple roles. It will look for all the policies and, if there's any role allowed, will let the request pass